### PR TITLE
Fix version number in "What's New in 4.60" newsletter

### DIFF
--- a/docs/manuals/newsletters/TN202003/TN202003.rst
+++ b/docs/manuals/newsletters/TN202003/TN202003.rst
@@ -1,9 +1,9 @@
 .. _tn202003:
 
-What’s new in Virtel 4.61 GA Release
+What’s new in Virtel 4.60 GA Release
 =====================================================
 
-The following newsletter summaries the new features and maintenance updates that can be found in Virtel Release 4.61. 
+The following newsletter summaries the new features and maintenance updates that can be found in Virtel Release 4.60. 
 
 Installation changes
 --------------------
@@ -12,9 +12,9 @@ Installation changes
 
 - Updated VSE installation tape with missing SCRNAPI macros
 
-**5832 V4.61 Installation updates**
+**5832 V4.60 Installation updates**
 
-- Updated MVS and VSE installation tapes with new JCL for v4.61
+- Updated MVS and VSE installation tapes with new JCL for v4.60
 
 **5865/5884 complete VSE and FSE installations**
 
@@ -27,12 +27,12 @@ Installation changes
 Migration considerations
 ------------------------
 
-V4.61 
+V4.60 
 ^^^^^
 
 **End of support for COMPATIBILITY mode**
 
-The "COMPATIBILITY" mode for w2hparm, that was introduced in version 4.54 to provide seamless migration of 4.53 w2hparm to 4.54 w2hparm is no longer supported in v4.61. It is recommended to switch to "Option" mode before migrating to 4.61.
+The "COMPATIBILITY" mode for w2hparm, that was introduced in version 4.54 to provide seamless migration of 4.53 w2hparm to 4.54 w2hparm is no longer supported in v4.60. It is recommended to switch to "Option" mode before migrating to 4.60.
 
 **ARBO changes**
 
@@ -488,7 +488,7 @@ Appendix A
 - 5829 incorrect display of a large template when using Virtel cache
 - 5830 Update to Virtel Online Doc. and Capture fix.
 - 5831 Allow DNS name in LINE definition
-- 5832 V4.61 Installation updates
+- 5832 V4.60 Installation updates
 - 5833 SCRNAPI updates containing @ sign are badly converted to EBCDIC
 - 5834 IPV6 rules and maps
 - 5835 Screen Presentation and Language Support Changes
@@ -546,7 +546,7 @@ Appendix B
 
 **IPv6 implementation guidelines**
 
-Virtel 4.61 introduces support of IPv6. 
+Virtel 4.60 introduces support of IPv6. 
 
 A Virtel line can now be defined to listen on a port associated with one of the following:
 


### PR DESCRIPTION
(version erroneously changed to 4.61 in 9 occurrences, including title)